### PR TITLE
[feat] CulturalEventListView에 id 필드 추가

### DIFF
--- a/Eiiii/category/views.py
+++ b/Eiiii/category/views.py
@@ -39,6 +39,7 @@ class CulturalEventListView(APIView):
                 status = "정보 없음"
 
             results.append({
+                "id": event.id, 
                 "title": event.title,
                 "date": event.date,
                 "place": event.place,


### PR DESCRIPTION
## 📌 개요
행사 리스트 API 응답에 id 필드를 추가했습니다.

## ✅ 작업 내용
- CulturalEventListView 결과 JSON에 id 값 포함
- 프론트엔드에서 클릭 시 상세 페이지 이동 시 id 사용 가능

## 📸 화면 캡처 (선택)
<img width="527" height="452" alt="image" src="https://github.com/user-attachments/assets/d14c2201-f46d-4a9e-b360-431a48c9b80d" />

## 🔍 중점 리뷰 요청 부분
- 프론트에서 id 기반 상세 페이지 요청 정상 동작 확인해주세욥

