### PR TITLE
[feat]: 평가/알고리즘 전체 개선 — 누수 방지, LLO 랭킹 평가, SVD 도입

### DIFF
--- a/Eiiii/recommend/algo.py
+++ b/Eiiii/recommend/algo.py
@@ -2,12 +2,16 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from sqlalchemy import create_engine
 import pandas as pd
-from surprise import Dataset, Reader
+from surprise import SVD, Dataset, Reader
 from surprise.model_selection import train_test_split
 from surprise import KNNBasic
 from surprise import accuracy
+from typing import List
 
 from behavior_based import calculate_activity_scores
+
+import numpy as np
+np.random.seed(42)
 
 import os, re, json
 from pathlib import Path
@@ -21,12 +25,40 @@ load_dotenv(dotenv_path=env_path, override=True)
 from konlpy.tag import Okt
 
 # ===== 공통 유틸 =====
+#전역 엔진 캐시
+_ENGINE = None
 def get_db_engine():
-    """PostgreSQL DB 엔진 생성"""
-    return create_engine(
-        f"postgresql+psycopg2://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}"
-        f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
-    )
+    global _ENGINE
+    if _ENGINE is None:
+        _ENGINE = create_engine(
+            f"postgresql+psycopg2://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}"
+            f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}",
+            pool_pre_ping=True, pool_size=5, max_overflow=10
+        )
+    return _ENGINE
+
+_VECTORIZER = None
+_EVENT_TFIDF = None
+
+def _ensure_vectorizer(event_texts: list[str]):
+    #이벤트 메타로만 fit: 사용자 희귀 토큰 소실 방지
+    global _VECTORIZER, _EVENT_TFIDF
+    if _VECTORIZER is None or _EVENT_TFIDF is None:
+        vec = TfidfVectorizer(
+            ngram_range=(1, 2),      # (1,3) → (1,2) 권장(성능/과적합 밸런스)
+            sublinear_tf=True,
+            min_df=3,                # 5 → 3 (희귀 토큰 보존)
+            max_features=20000
+        )
+        _EVENT_TFIDF = vec.fit_transform(event_texts)
+        _VECTORIZER = vec
+
+def calculate_similarity(event_df: pd.DataFrame, user_profile: str) -> pd.Series:
+    texts = event_df['meta'].tolist()
+    _ensure_vectorizer(texts)
+    user_vec = _VECTORIZER.transform([user_profile or ""])
+    sims = cosine_similarity(_EVENT_TFIDF, user_vec).ravel()
+    return pd.Series(sims, index=event_df.index)
 
 # 1. 회원가입 초기: 콘텐츠 기반 필터링
 #    데이터: 카테고리 / 지역 / 유, 무료 / 테마
@@ -47,6 +79,29 @@ def preprocess_text(text):
 
     return ' '.join(tokens)
 
+def preprocess_title(title: str) -> str:
+    """
+    공연/행사 제목 문자열을 전처리:
+    1) 괄호([]) 안 내용 제거
+    2) 특수문자, 숫자 제거
+    3) 형태소 분석 후 명사/형용사만 추출
+    4) 공백으로 연결한 문자열 반환
+    """
+    if not isinstance(title, str):
+        return ""
+    
+    # 1) 대괄호 안 내용 제거
+    text = re.sub(r"\[.*?\]", " ", title)
+    
+    # 2) 숫자, 특수문자 제거
+    text = re.sub(r"[^가-힣a-zA-Z\s]", " ", text)
+    
+    # 3) 형태소 분석 (명사/형용사만)
+    tokens = [word for word, pos in okt.pos(text) if pos in ["Noun", "Adjective"]]
+    
+    # 4) 공백 기준 문자열 반환
+    return " ".join(tokens)
+
 # ===== 행사 데이터 로드 =====
 def load_event_data():
     """
@@ -66,7 +121,10 @@ def load_event_data():
     df["codename"]  = df["codename"].fillna("")
     df["title"]     = df["title"].fillna("")
 
-    df["meta_raw"] = df[["codename", 'guname', "is_free", "themecode", "title"]].astype(str).agg(" ".join, axis=1)
+    # title 전처리 적용
+    df["title_clean"] = df["title"].apply(preprocess_title)
+
+    df["meta_raw"] = df[["codename", 'guname', "is_free", "themecode", "title_clean"]].astype(str).agg(" ".join, axis=1)
     df["meta"] = df["meta_raw"].apply(preprocess_text)
     return df
 
@@ -127,37 +185,46 @@ def load_user_profile(user_id: int):
     return preprocess_text(' '.join(user_mapped.values()))
 
 # ===== TF-IDF로 사용자와 행사 유사도 계산 =====
-def calculate_similarity(event_df, user_profile):
-    corpus = event_df['meta'].tolist() + [user_profile]
-    tfidf = TfidfVectorizer(
-        ngram_range=(1, 3), 
-        sublinear_tf=True, 
-        min_df=5,
-        max_features=15000
-        )
-    tfidf_matrix = tfidf.fit_transform(corpus)
-    cosine_sim = cosine_similarity(tfidf_matrix[:-1], tfidf_matrix[-1]).flatten()
-    return pd.Series(cosine_sim, index=event_df.index)
+#def calculate_similarity(event_df, user_profile):
+#    corpus = event_df['meta'].tolist() + [user_profile]
+#    tfidf = TfidfVectorizer(
+#        ngram_range=(1, 3), 
+#        sublinear_tf=True, 
+#        min_df=5,
+#        max_features=15000
+#        )
+#    tfidf_matrix = tfidf.fit_transform(corpus)
+#    cosine_sim = cosine_similarity(tfidf_matrix[:-1], tfidf_matrix[-1]).flatten()
+#    return pd.Series(cosine_sim, index=event_df.index)
 
 # 사용자 관심사 불러오기
-def load_user_interests(user_id):
-    """
-    DB에서 user_id로 사용자의 관심사 데이터를 불러와 dict 형태로 반환
-    예:
-    """
+#def load_user_interests(user_id):
+#    """
+#    DB에서 user_id로 사용자의 관심사 데이터를 불러와 dict 형태로 반환
+#    예:
+#    """
+#    engine = get_db_engine()
+#    query = f"""
+#        SELECT interests, fee_type, area, together_input
+#        FROM profiles_userprofile
+#        WHERE user_id = {user_id}
+#    """
+#    df = pd.read_sql(query, engine)
+
+#    # df를 dict로 변환
+#    if not df.empty:
+#        return df.iloc[0].to_dict()
+#   else:
+#        return {}
+def load_user_interests(user_id: int) -> dict:
     engine = get_db_engine()
-    query = f"""
+    query = """
         SELECT interests, fee_type, area, together_input
         FROM profiles_userprofile
-        WHERE user_id = {user_id}
+        WHERE user_id = %s
     """
-    df = pd.read_sql(query, engine)
-
-    # df를 dict로 변환
-    if not df.empty:
-        return df.iloc[0].to_dict()
-    else:
-        return {}
+    df = pd.read_sql(query, engine, params=(user_id,))
+    return df.iloc[0].to_dict() if not df.empty else {}
 
 # 1. 콘텐츠 기반 추천
 def content_based_recommend_df(user_id: int, top_n=10) -> pd.DataFrame:
@@ -169,12 +236,13 @@ def content_based_recommend_df(user_id: int, top_n=10) -> pd.DataFrame:
                     .head(top_n)
                     .reset_index(drop=True))
 
-def content_based_recommend_ids(user_id: int, top_n=10) -> list[int]:
-    return content_based_recommend_df(user_id, top_n)['id'].astype(int).tolist()
-
 # 정밀도 검사에서 호환용 별칭 
 content_based_recommend = content_based_recommend_df
-cb_recommend_ids = content_based_recommend_ids
+#cb_recommend_ids = content_based_recommend_ids
+def content_based_recommend_ids(user_id: int, top_n=10) -> list[int]:
+    df = content_based_recommend_df(user_id, top_n)
+    return df['id'].dropna().astype(int).tolist()
+# 중복 정의되어 있던 cb_recommend_ids 제거
 
 # ===== top-k id 만 뽑기 =====
 def cb_recommend_ids(user_id: int, top_k=10):
@@ -188,15 +256,24 @@ def behavior_adjusted_recommend(user_id, top_n=10):
     user_profile = load_user_profile(user_id)
     event_df['similarity'] = calculate_similarity(event_df, user_profile).round(4)
 
-    scores, _ = calculate_activity_scores(user_id)
+    scores, _ = calculate_activity_scores(user_id)  # {event_id: score}
+    # 안정화: 사용자 단위 min-max (분산 0이면 0 처리)
+    if scores:
+        s = pd.Series(scores)
+        if s.max() > s.min():
+            s = (s - s.min()) / (s.max() - s.min())
+        else:
+            s = s*0.0
+        adj_factor = event_df['id'].map(s).fillna(0.0)
+    else:
+        adj_factor = pd.Series(0.0, index=event_df.index)
 
-    # 행동 점수 반영
-    event_df['adjusted_similarity'] = event_df.apply(
-        lambda row: round(row['similarity'] * (1 + scores.get(row['id'], 0)), 4),
-        axis=1
-    )
+    event_df['adjusted_similarity'] = (event_df['similarity'] * (1 + adj_factor)).round(4)
 
     filtered_df = event_df[event_df['similarity'] > 0.2]
+    if filtered_df.empty:
+        filtered_df = event_df
+
     return filtered_df.sort_values('adjusted_similarity', ascending=False).head(top_n)
 
 # 3. 협업 필터링 함수
@@ -207,8 +284,15 @@ def behavior_adjusted_recommend(user_id, top_n=10):
 
 # 사용자 평점 데이터 불러오기
 def load_ratings():
-    engine = get_db_engine()
-    return pd.read_sql("SELECT user_id, event_id, rating FROM surveys_surveyreview;", engine)
+    eng = get_db_engine()
+    df = pd.read_sql("""
+        SELECT user_id, event_id, rating, created_at::timestamp AS created_at
+        FROM surveys_surveyreview
+        WHERE rating IS NOT NULL
+    """, eng)
+    df['created_at'] = pd.to_datetime(df['created_at'])
+    df = df.sort_values('created_at').drop_duplicates(['user_id','event_id'], keep='last')
+    return df[['user_id','event_id','rating']]
 
 # Surprise 형식으로 변환 
 def prepare_dataset(df):
@@ -223,31 +307,48 @@ def collaborative_filtering_recommend(user_id, top_n=5):
     ratings_df = load_ratings()
     if ratings_df.empty:
         return []
+    
+    # 유저가 아예 평점 기록이 없으면 CB로 폴백
+    if user_id not in set(ratings_df['user_id'].unique()):
+        cb = content_based_recommend_df(user_id, top_n)
+        if cb.empty:
+            return []
+        cb = cb.copy()
+        cb.rename(columns={'similarity': 'pred_rating'}, inplace=True)
+        return cb  # id, title, pred_rating 형태와 호환
 
-    data = prepare_dataset(ratings_df)
-    trainset, _ = train_test_split(data, test_size=0.2)
-    algo = KNNBasic(sim_options={'name': 'cosine', 'user_based': True})
+    reader = Reader(rating_scale=(0,5))
+    data = Dataset.load_from_df(ratings_df[['user_id','event_id','rating']], reader)
+    trainset = data.build_full_trainset()
+
+    algo = SVD(n_factors=10, n_epochs=30, reg_all=0.05, random_state=42)
     algo.fit(trainset)
 
-    unrated_items = get_unrated_events(user_id, ratings_df, ratings_df['event_id'].unique())
-    if not unrated_items:
+    # 후보: 학습에 등장한 아이템들 중 사용자가 아직 안 본 것
+    all_items = set(ratings_df['event_id'].unique())
+    seen = set(ratings_df.loc[ratings_df['user_id'] == user_id, 'event_id'].unique())
+    candidates = list(all_items - seen)
+    if not candidates:
         return []
 
-    predictions = [(eid, algo.predict(user_id, eid).est) for eid in unrated_items]
-    top_preds = sorted(predictions, key=lambda x: x[1], reverse=True)[:top_n]
+    scored = [(iid, algo.predict(user_id, iid, clip=False).est) for iid in candidates]
+    top_preds = sorted(scored, key=lambda x: x[1], reverse=True)[:top_n]
+    ids_ordered = [int(eid) for eid, _ in top_preds]
 
-    engine = get_db_engine()
-    top_event_ids = [int(p[0]) for p in top_preds]
-    placeholders = ', '.join(['%s'] * len(top_event_ids))
-    query = f"""
-        SELECT id, title, category, guname, use_fee, main_img, place, start_date, end_date
+    # 이벤트 메타 가져오고 원래 순서 유지
+    eng = get_db_engine()
+    placeholders = ', '.join(['%s'] * len(ids_ordered))
+    q = f"""
+        SELECT id, title, codename, guname, use_fee, main_img, place, start_date, end_date
         FROM search_culturalevent
         WHERE id IN ({placeholders})
     """
-    event_df = pd.read_sql(query, engine, params=tuple(top_event_ids))
+    ev = pd.read_sql(q, eng, params=tuple(ids_ordered))
+    ev['__order'] = pd.Categorical(ev['id'], ids_ordered, ordered=True)
+    ev = ev.sort_values('__order').drop(columns='__order')
 
     pred_df = pd.DataFrame(top_preds, columns=['id', 'pred_rating'])
-    return event_df.merge(pred_df, on='id').sort_values('pred_rating', ascending=False)
+    return ev.merge(pred_df, on='id')
 
 def evaluate_cf_rmse_mae(ratings_df):
     data = prepare_dataset(ratings_df)
@@ -364,7 +465,7 @@ def compute_cf_scores(user_id: int, top_k: int = None) -> pd.DataFrame:
 def hybrid_recommend(
     user_id: int,
     top_n: int = 10,
-    weights: tuple = (0.0, 0.0, 1.0),  # 각 추천 점수의 가중치 (w_cb, w_beh, w_cf)
+    weights: tuple = (0.5, 0.2, 0.3),  # 각 추천 점수의 가중치 (w_cb, w_beh, w_cf)
     dedup: bool = True,
     min_components: int = 1,           # 최소 몇 개 축에서 점수가 있어야 포함할지(0~3)
     return_components: bool = True     # 부분 점수 컬럼 포함 여부
@@ -422,7 +523,7 @@ def hybrid_recommend(
 
 
 if __name__ == "__main__":
-    user_id = 1
+    user_id = 147
     # user_interest = {
     #     "interests": ["클래식", "축제-기타", "콘서트"],
     #     "area": "성북구",
@@ -431,14 +532,14 @@ if __name__ == "__main__":
     # }
 
     ratings_df = load_ratings()
-    hybrid_df = hybrid_recommend(user_id, top_n=10, weights=(0.0, 0.0, 1.0))
+    hybrid_df = hybrid_recommend(user_id, top_n=10, weights=(0.5, 0.2, 0.3))
 
     print("@@@@@@@@@ 콘텐츠 기반 추천 @@@@@@@@@")
     print(content_based_recommend(user_id, top_n=5)[['title','similarity']])
     print("@@@@@@@@@ 행동 기반 추천 @@@@@@@@@")
     print(behavior_adjusted_recommend(user_id, top_n=5)[['title','adjusted_similarity']])
     print("@@@@@@@@@ 협업 필터링 추천 @@@@@@@@@")
-    print(collaborative_filtering_recommend(1, top_n=5)[['title','pred_rating']])
+    print(collaborative_filtering_recommend(user_id, top_n=5)[['title','pred_rating']])
     print(evaluate_cf_rmse_mae(ratings_df))
     print("@@@@@@@@@ 하이브리드 추천 @@@@@@@@@")
     print(hybrid_df)

--- a/Eiiii/recommend/behavior_based.py
+++ b/Eiiii/recommend/behavior_based.py
@@ -1,8 +1,11 @@
 from sqlalchemy import create_engine, text
-import os
+import os, math
+from collections import defaultdict
+from datetime import datetime, timezone
 from dotenv import load_dotenv
 from pathlib import Path
-from geopy.distance import geodesic  # 거리 계산용
+from geopy.distance import geodesic
+from typing import Tuple, Dict, Any, Iterable
 
 # 환경변수 로드
 env_path = Path(__file__).resolve().parent.parent / "Eiiii" / ".env"
@@ -14,87 +17,202 @@ def get_db_engine():
         f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
     )
 
-#행동 기반 추천 점수 계산
-def calculate_activity_scores(user_id):
+# 선호도(카테고리/지역) 계산 헬퍼
+# -----------------------------
+def _build_user_prefs(conn, user_id: int, cutoff_ts=None, lambda_per_day: float = 0.02):
+    """
+    cutoff 이전의 (좋아요+리뷰)로부터 유저의 카테고리/지역 선호를 시간감쇠로 집계.
+    반환: (pref_cat: dict[str,float], pref_area: dict[str,float])
+    """
+    cut_clause = "AND created_at < :cutoff" if cutoff_ts else ""
+    params = {"uid": user_id}
+    if cutoff_ts:
+        params["cutoff"] = cutoff_ts
+
+    rows = conn.execute(text(f"""
+        WITH inter AS (
+            SELECT event_id, created_at FROM details_culturaleventlike
+             WHERE user_id = :uid {cut_clause}
+            UNION ALL
+            SELECT event_id, created_at FROM surveys_surveyreview
+             WHERE user_id = :uid {cut_clause}
+        )
+        SELECT e.codename, e.guname, inter.created_at
+          FROM inter
+          JOIN search_culturalevent e ON e.id = inter.event_id
+         WHERE (e.codename IS NOT NULL OR e.guname IS NOT NULL)
+    """), params).fetchall()
+
+    # now 기준: cutoff 있으면 cutoff, 없으면 현재 UTC (둘 다 tz-aware로 통일)
+    if isinstance(cutoff_ts, datetime):
+        now = cutoff_ts if cutoff_ts.tzinfo else cutoff_ts.replace(tzinfo=timezone.utc)
+    else:
+        now = datetime.now(timezone.utc)
+
+    cat = defaultdict(float)
+    area = defaultdict(float)
+    for codename, guname, ts in rows:
+        if isinstance(ts, datetime):
+            ts_aware = ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+            delta_days = max((now - ts_aware).days, 0)
+        else:
+            delta_days = 0
+        w = math.exp(-lambda_per_day * float(delta_days))  # 더 최근일수록 가중↑
+        if codename:
+            cat[str(codename)] += w
+        if guname:
+            area[str(guname)] += w
+
+    # 확률 정규화(없으면 빈 dict)
+    s_cat = sum(cat.values())
+    s_area = sum(area.values())
+    pref_cat = {k: v / s_cat for k, v in cat.items()} if s_cat > 0 else {}
+    pref_area = {k: v / s_area for k, v in area.items()} if s_area > 0 else {}
+    return pref_cat, pref_area
+
+
+def calculate_activity_scores(
+    user_id: int,
+    cutoff_ts=None,
+    exclude_event_ids: Iterable[int] = None,
+    W_DIST: float = 0.6,   # 거리 가중
+    W_CAT: float = 0.25,   # 카테고리 선호 가중
+    W_AREA: float = 0.15   # 지역 선호 가중
+) -> Tuple[Dict[int, float], Dict[int, Dict[str, Any]]]:
+    """
+    행동 기반 추천 점수 계산(누수 방지 + 선호도 적용)
+      - 거리 점수: 10km 이내 1.0, 멀수록 선형감소
+      - 선호 점수: cutoff 이전 행동으로 추정한 카테고리/지역 선호(시간감쇠)
+      - 직접 가점: 좋아요 +1.0, 리뷰 +2.5~3.0 (단, exclude_event_ids에는 적용하지 않음)
+
+    반환: (scores, details)
+      scores  = {event_id: total_score}
+      details = {event_id: {...중간항목...}}
+    """
+    exclude_event_ids = set(exclude_event_ids or [])
+
     engine = get_db_engine()
-    conn = engine.connect()
+    with engine.connect() as conn:
+        # 유저 좌표
+        row = conn.execute(
+            text("SELECT latitude, longitude FROM accounts_customuser WHERE id=:uid"),
+            {"uid": user_id}
+        ).fetchone()
+        if not row or row[0] is None or row[1] is None:
+            return {}, {}
 
-    # 유저 정보 가져오기 (좌표)
-    user_query = text("SELECT latitude, longitude FROM accounts_customuser WHERE id = :user_id")
-    user_loc = conn.execute(user_query, {"user_id": user_id}).fetchone()
+        u_lat, u_lon = float(row[0]), float(row[1])
 
-    if not user_loc:
-        return {}
+        # 유저 선호(카테고리/지역) 추정
+        pref_cat, pref_area = _build_user_prefs(conn, user_id, cutoff_ts=cutoff_ts, lambda_per_day=0.02)
 
-    user_latitude, user_longitude = user_loc
-    scores = {}
-    details = {}  # 점수 요소별 저장
+        # 이벤트 메타 + 좌표 로드 (lat/lot 스왑 주의: lot=위도, lat=경도)
+        events = conn.execute(text("""
+            SELECT
+                id,
+                title,
+                lot AS lat,    -- 위도
+                lat AS lon,    -- 경도
+                codename,
+                guname
+            FROM search_culturalevent
+            WHERE lat IS NOT NULL AND lot IS NOT NULL
+        """)).fetchall()
 
-    #거리 기반 점수
-    event_query = text("SELECT id, title, lat, lot FROM search_culturalevent WHERE lat IS NOT NULL AND lot IS NOT NULL")
-    events = conn.execute(event_query).fetchall()
+        scores: Dict[int, float] = {}
+        details: Dict[int, Dict[str, Any]] = {}
 
-    for event in events:
-        event_id, title, lot, lat = event
-        event_latitude = float(lat)
-        event_longitude = float(lot)
+        # 1) 거리 + 선호 점수
+        for eid, title, ev_lat, ev_lon, codename, guname in events:
+            try:
+                d_km = geodesic((u_lat, u_lon), (float(ev_lat), float(ev_lon))).km
+            except Exception:
+                # 좌표 이상치면 해당 이벤트 스킵
+                continue
+            dist_score = max(0.0, 1.0 - d_km / 10.0)
 
-        distance_km = geodesic(
-            (user_latitude, user_longitude),
-            (event_latitude, event_longitude)
-        ).km
-        distance_score = max(0, 1 - distance_km / 10) # 가까울수록 점수 높게: 10km 이내면 +1, 멀수록 0으로 감소
-        scores[event_id] = distance_score
-        details[event_id] = {
-            "title": title,
-            "distance_score": distance_score,
-            "review_score": 0,
-            "like_score": 0
-        }
+            # 선호(0~1): 없으면 0
+            cat_pref = pref_cat.get(str(codename), 0.0)
+            area_pref = pref_area.get(str(guname), 0.0)
+            pref_score = W_CAT * cat_pref + W_AREA * area_pref
 
-        #print("유저:", user_latitude, user_longitude)
-        #print("이벤트:", event_latitude, event_longitude)
+            base = W_DIST * dist_score + pref_score
 
-    #좋아요 +1점
-    like_query = text("SELECT event_id FROM details_culturaleventlike WHERE user_id = :user_id")
-    liked = conn.execute(like_query, {"user_id": user_id}).fetchall()
-    for row in liked:
-        event_id = row[0]
-        if event_id in scores:
-            scores[event_id] += 1.0
-            details[event_id]["like_score"] = 1.0
+            scores[eid] = base
+            details[eid] = {
+                "title": title,
+                "distance_score": dist_score,
+                "cat_pref": cat_pref,
+                "area_pref": area_pref,
+                "like_score": 0.0,
+                "review_score": 0.0,
+                "total_score": base,
+            }
 
-    #리뷰 작성 +2점, 평점 +0.5~+1점
-    review_query = text("SELECT event_id, rating FROM surveys_surveyreview WHERE user_id = :user_id")
-    reviews = conn.execute(review_query, {"user_id": user_id}).fetchall()
-    #print("리뷰 기반 가중치용 리뷰 목록:", reviews)
-    for event_id, rating in reviews:
-        if event_id in scores:
-            review_score = 2 + (0.5 + 0.1 * rating)  # 기본 2점 + 평점 기반 추가 점수 긍까 평점 5점 주면 1.0추가, 4점 주면 0.9추가..
-            scores[event_id] += review_score
-            details[event_id]["review_score"] = review_score
-    
-    # 최종 종합 점수
-    for event_id in scores:
-        details[event_id]["total_score"] = scores[event_id]
+        # cutoff 절
+        cut_clause = "AND created_at < :cutoff" if cutoff_ts else ""
+        params = {"uid": user_id}
+        if cutoff_ts:
+            params["cutoff"] = cutoff_ts
 
-    conn.close()
-    return scores, details
+        # 2) 좋아요 가점 (+1.0) — 좌표 없던 이벤트도 포함(세부정보는 title None)
+        like_rows = conn.execute(text(f"""
+            SELECT event_id
+            FROM details_culturaleventlike
+            WHERE user_id = :uid {cut_clause}
+        """), params).fetchall()
+
+        for (eid,) in like_rows:
+            if eid in exclude_event_ids:
+                continue
+            if eid not in scores:
+                scores[eid] = 0.0
+                details[eid] = {
+                    "title": None, "distance_score": 0.0,
+                    "cat_pref": 0.0, "area_pref": 0.0,
+                    "like_score": 0.0, "review_score": 0.0, "total_score": 0.0
+                }
+            scores[eid] += 1.0
+            details[eid]["like_score"] += 1.0
+            details[eid]["total_score"] = scores[eid]
+
+        # 3) 리뷰 가점 (+2.0 + 평점 보정)
+        review_rows = conn.execute(text(f"""
+            SELECT event_id, rating
+            FROM surveys_surveyreview
+            WHERE user_id = :uid {cut_clause}
+        """), params).fetchall()
+
+        for eid, rating in review_rows:
+            if eid in exclude_event_ids:
+                continue
+            if eid not in scores:
+                scores[eid] = 0.0
+                details[eid] = {
+                    "title": None, "distance_score": 0.0,
+                    "cat_pref": 0.0, "area_pref": 0.0,
+                    "like_score": 0.0, "review_score": 0.0, "total_score": 0.0
+                }
+            add = 2.0 + (0.5 + 0.1 * float(rating or 0))  # 2.5~3.0
+            scores[eid] += add
+            details[eid]["review_score"] += add
+            details[eid]["total_score"] = scores[eid]
+
+        return scores, details
 
 
-#테스트
+# 테스트
 if __name__ == "__main__":
     user_id = 3
-    result = calculate_activity_scores(user_id)
+    scores, details = calculate_activity_scores(user_id, cutoff_ts=None)
 
-    sorted_result = sorted(result.items(), key=lambda x: x[1]["total_score"], reverse=True)
+    # total_score 기준 상위 10개 출력
+    sorted_items = sorted(details.items(), key=lambda x: x[1].get("total_score", 0.0), reverse=True)
 
     print("\n추천 결과 (상위 10개):")
-    for rank, (event_id, data) in enumerate(sorted_result[:10], 1):
-        print(f"{rank}위. [{data['title']}] (ID: {event_id})")
-        print(f"      거리점수: {data['distance_score']:.3f}")
-        print(f"      좋아요점수: {data['like_score']:.3f}")
-        print(f"      리뷰점수: {data['review_score']:.3f}")
-        print(f"      총점: {data['total_score']:.3f}\n")
-
-    
+    for rank, (event_id, data) in enumerate(sorted_items[:10], 1):
+        print(f"{rank}위. [{data.get('title')}] (ID: {event_id})")
+        print(f"      거리점수: {data.get('distance_score', 0.0):.3f}")
+        print(f"      좋아요점수: {data.get('like_score', 0.0):.3f}")
+        print(f"      리뷰점수: {data.get('review_score', 0.0):.3f}")
+        print(f"      총점: {data.get('total_score', 0.0):.3f}\n")

--- a/Eiiii/recommend/evaluation_wish.py
+++ b/Eiiii/recommend/evaluation_wish.py
@@ -1,0 +1,308 @@
+import os, random
+import numpy as np
+import pandas as pd
+from typing import Dict, List, Tuple, Set
+from collections import defaultdict
+from datetime import datetime
+
+from sqlalchemy import create_engine
+
+from surprise import Dataset, Reader, SVD, KNNBaseline
+from surprise.model_selection import KFold
+from surprise import accuracy
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+# 환경변수 로드
+env_path = Path(__file__).resolve().parent.parent / "Eiiii" / ".env"
+load_dotenv(dotenv_path=env_path)
+
+def get_db_engine():
+    return create_engine(
+        f"postgresql+psycopg2://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}"
+        f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
+    )
+
+# ===== 공통 유틸: 랭킹 지표 =====
+def precision_at_k(recommended: List[int], positives: Set[int], k: int) -> float:
+    rec_k = recommended[:k]
+    hit = sum(1 for eid in rec_k if eid in positives)
+    return hit / max(1, k)
+
+def recall_at_k(recommended: List[int], positives: Set[int], k: int) -> float:
+    rec_k = recommended[:k]
+    hit = sum(1 for eid in rec_k if eid in positives)
+    return hit / max(1, len(positives))
+
+def apk(recommended: List[int], positives: Set[int], k: int) -> float:
+    """Average Precision@K"""
+    score = 0.0
+    hit = 0
+    for i, eid in enumerate(recommended[:k], start=1):
+        if eid in positives:
+            hit += 1
+            score += hit / i
+    return score / max(1, min(len(positives), k))
+
+def dcg_at_k(recommended: List[int], positives: Set[int], k: int) -> float:
+    dcg = 0.0
+    for i, eid in enumerate(recommended[:k], start=1):
+        rel = 1.0 if eid in positives else 0.0
+        dcg += rel / np.log2(i + 1)
+    return dcg
+
+def ndcg_at_k(recommended: List[int], positives: Set[int], k: int) -> float:
+    ideal_hits = min(len(positives), k)
+    idcg = sum(1.0 / np.log2(i + 1) for i in range(1, ideal_hits + 1))
+    if idcg == 0:
+        return 0.0
+    return dcg_at_k(recommended, positives, k) / idcg
+
+# ===== A) 행동 기반 평가 =====
+# details_culturaleventlike: id, created_at, event_id, user_id
+# surveys_surveyreview:     id, content, extra_feedback, created_at, event_id, user_id, photo, rating
+def load_interactions(engine) -> pd.DataFrame:
+    like_sql = """
+        SELECT user_id, event_id, created_at::timestamp AS ts, 'like' AS type
+        FROM details_culturaleventlike
+    """
+    review_sql = """
+        SELECT user_id, event_id, created_at::timestamp AS ts, 'review' AS type
+        FROM surveys_surveyreview
+    """
+    like_df = pd.read_sql(like_sql, engine)
+    rev_df  = pd.read_sql(review_sql,  engine)
+    df = pd.concat([like_df, rev_df], ignore_index=True)
+    df['ts'] = pd.to_datetime(df['ts'])
+    return df
+
+def build_user_splits(df: pd.DataFrame, test_holdout_per_user: int = 1):
+    """
+    각 유저별 시간순으로 정렬 후 마지막 n개를 테스트로 홀드아웃.
+    반환: {user_id: (train_event_ids, test_event_ids)}
+    """
+    splits = {}
+    for uid, g in df.sort_values('ts').groupby('user_id'):
+        events = g['event_id'].tolist()
+        if len(events) <= test_holdout_per_user:
+            continue
+        test = set(events[-test_holdout_per_user:])
+        train = set(events[:-test_holdout_per_user]) - test
+        splits[uid] = (train, test)
+    return splits
+
+def evaluate_behavior_model(engine, k: int = 10, negative_pool: int = 100, seed: int = 42):
+    import random
+    random.seed(seed); np.random.seed(seed)
+    from behavior_based import calculate_activity_scores
+
+    interactions = load_interactions(engine)
+    interactions = interactions.dropna(subset=["user_id","event_id","ts"])
+    interactions = interactions.sort_values("ts")
+
+    splits, cutoffs = {}, {}
+    for uid, g in interactions.groupby('user_id'):
+        evs = g[['event_id','ts']].values.tolist()
+        if len(evs) <= 1:
+            continue
+        last_eid, last_ts = evs[-1]
+        train_eids = {e for e,_ in evs[:-1]}
+        test_eids  = {last_eid}
+        splits[uid] = (train_eids, test_eids)
+        cutoffs[uid] = last_ts
+
+    all_events = pd.read_sql("SELECT id FROM search_culturalevent", engine)['id'].tolist()
+
+    metrics = defaultdict(list)
+    n_users = 0
+    for uid, (train_set, test_set) in splits.items():
+        cutoff = cutoffs[uid]
+        # 테스트 아이템 가점 누수 방지
+        scores, _ = calculate_activity_scores(uid, cutoff_ts=cutoff, exclude_event_ids=test_set)
+
+        negatives = [e for e in all_events if e not in train_set and e not in test_set]
+        if len(negatives) > negative_pool:
+            negatives = random.sample(negatives, negative_pool)
+        candidates = list(test_set) + negatives
+
+        ranked = sorted(candidates, key=lambda x: scores.get(x, 0.0), reverse=True)
+
+        metrics['precision@k'].append(precision_at_k(ranked, test_set, k))
+        metrics['recall@k'].append(recall_at_k(ranked, test_set, k))
+        metrics['map@k'].append(apk(ranked, test_set, k))
+        metrics['ndcg@k'].append(ndcg_at_k(ranked, test_set, k))
+        n_users += 1
+
+    out = {m: float(np.mean(v)) if v else 0.0 for m, v in metrics.items()}
+    print(f"[Behavior Eval] evaluated_users={n_users}, k={k}, negative_pool={negative_pool}")
+    return out
+
+# ===== B) 협업 필터링 평가 (KNNBaseline vs SVD) =====
+def load_ratings(engine) -> pd.DataFrame:
+    sql = """
+        SELECT user_id, event_id, rating, created_at::timestamp AS created_at
+        FROM surveys_surveyreview
+        WHERE rating IS NOT NULL
+    """
+    df = pd.read_sql(sql, engine)
+    df['created_at'] = pd.to_datetime(df['created_at'])
+    df = df.dropna(subset=['created_at'])
+    # (user,item) 중복 제거: 가장 최근 것만 유지
+    df = df.sort_values('created_at').drop_duplicates(['user_id', 'event_id'], keep='last')
+    return df
+
+def eval_surprise_rmse_mae(ratings_df: pd.DataFrame):
+    reader = Reader(rating_scale=(0,5))
+    data = Dataset.load_from_df(ratings_df[['user_id','event_id','rating']], reader)
+
+    # 너무 작은 데이터에서 5-fold가 불가능한 경우 대비
+    n_splits = 5
+    if ratings_df.shape[0] < 5:
+        n_splits = 3
+    kf = KFold(n_splits=n_splits, random_state=42, shuffle=True)
+
+    results = {}
+    algos = {
+        "KNNBaseline": KNNBaseline(sim_options={'name':'pearson_baseline','user_based':False}),
+        "SVD": SVD(n_factors=20, n_epochs=50, reg_all=0.02, random_state=42),
+    }
+    
+    for name, algo in algos.items():
+        rmses, maes = [], []
+        for trainset, testset in kf.split(data):
+            algo.fit(trainset)
+            preds = algo.test(testset)
+            rmses.append(accuracy.rmse(preds, verbose=False))
+            maes.append(accuracy.mae(preds, verbose=False))
+        results[name] = {"RMSE": float(np.mean(rmses)), "MAE": float(np.mean(maes))}
+    return results
+
+def eval_surprise_ranking(
+    ratings_df: pd.DataFrame,
+    k: int = 10,
+    negative_pool: int | None = 300,   # 후보가 너무 많을 때만 다운샘플
+    use_all_candidates: bool = True,   # True = 하드 네거티브(추천 난이도 ↑)
+    skip_cold: bool = True             # 테스트 아이템이 train에 전혀 없으면 스킵
+):
+    import random
+    random.seed(42); np.random.seed(42)
+    reader = Reader(rating_scale=(0,5))
+
+    # (user,item) 중복 제거 + 시간 정렬
+    df = ratings_df.sort_values('created_at').drop_duplicates(['user_id','event_id'], keep='last')
+
+    # 유저 필터: 상호작용(유니크 아이템) >= 3
+    counts = df.groupby('user_id')['event_id'].nunique()
+    keep_users = set(counts[counts >= 3].index)
+    df = df[df['user_id'].isin(keep_users)].copy()
+    if df.empty:
+        return {"error": "Not enough users with >=3 interactions."}
+
+    # 글로벌 아이템 출현 빈도
+    freq = df['event_id'].value_counts()
+
+    # 테스트 인덱스: "가장 최근이면서, 해당 아이템이 train에 최소 1회 남는" 것을 우선 선택
+    test_idx = []
+    train = df.copy()
+    for uid, g in df.groupby('user_id'):
+        g = g.sort_values('created_at')
+        chosen = None
+        # 뒤에서부터 탐색
+        for i in range(len(g) - 1, -1, -1):
+            row = g.iloc[i]
+            eid = row['event_id']
+            # 현재 train에서 이 아이템의 개수(이 사용자의 이 행을 drop한다고 가정하면 -1)
+            eid_count_in_train = (train['event_id'] == eid).sum()
+            if eid_count_in_train - 1 > 0:
+                chosen = row.name
+                break
+        # 모두 cold가 될 경우엔 마지막 행 사용(어쩔 수 없음)
+        if chosen is None:
+            chosen = g.iloc[-1].name
+
+        test_idx.append(chosen)
+        # 실제로 train에서 제거하여 다음 유저 선택 시 반영
+        train = train.drop(index=[chosen])
+
+    test_pairs = df.loc[test_idx, ['user_id','event_id','created_at']]
+    train_items = set(train['event_id'].unique())
+    # 학습
+    train_data = Dataset.load_from_df(train[['user_id','event_id','rating']], reader)
+    trainset = train_data.build_full_trainset()
+
+    algos = {
+        "KNNBaseline": KNNBaseline(sim_options={'name':'pearson_baseline','user_based':False, 'min_k': 3}),
+        "SVD": SVD(n_factors=10, n_epochs=30, reg_all=0.05, random_state=42),
+    }
+
+    out = {}
+    for name, algo in algos.items():
+        algo.fit(trainset)
+        precs, recs, maps, ndcgs = [], [], [], []
+        evaluated = 0
+        skipped_cold = 0
+
+        for _, row in test_pairs.iterrows():
+            uid = int(row['user_id']); pos_item = int(row['event_id'])
+            seen = set(train.loc[train['user_id'] == uid, 'event_id'])
+
+            if use_all_candidates:
+                candidates = list(train_items - seen)
+                if skip_cold and pos_item not in train_items:
+                    skipped_cold += 1
+                    continue
+                if negative_pool is not None and len(candidates) > negative_pool:
+                    if pos_item in candidates:
+                        candidates.remove(pos_item)
+                        candidates = random.sample(candidates, negative_pool - 1) + [pos_item]
+                    else:
+                        candidates = random.sample(candidates, negative_pool) + [pos_item]
+                else:
+                    if pos_item not in candidates:
+                        candidates.append(pos_item)
+            else:
+                candidates = list(train_items - seen - {pos_item})
+                if negative_pool is not None and len(candidates) > negative_pool:
+                    candidates = random.sample(candidates, negative_pool)
+                candidates.append(pos_item)
+
+            scored = [(iid, algo.predict(uid, iid, clip=False).est) for iid in candidates]
+            ranked = [iid for iid, _ in sorted(scored, key=lambda x: x[1], reverse=True)]
+            positives = {pos_item}
+
+            precs.append(precision_at_k(ranked, positives, k))
+            recs.append(recall_at_k(ranked, positives, k))
+            maps.append(apk(ranked, positives, k))
+            ndcgs.append(ndcg_at_k(ranked, positives, k))
+            evaluated += 1
+
+        out[name] = {
+            "precision@k": float(np.mean(precs)) if precs else 0.0,
+            "recall@k": float(np.mean(recs)) if recs else 0.0,
+            "map@k": float(np.mean(maps)) if maps else 0.0,
+            "ndcg@k": float(np.mean(ndcgs)) if ndcgs else 0.0,
+        }
+        print(f"[CF Rank:{name}] evaluated_users={evaluated}, skipped_cold={skipped_cold}, "
+              f"avg_candidates={(len(candidates) if evaluated else 0)}")
+    return out
+
+# ===== 실행 예시 =====
+if __name__ == "__main__":
+    np.random.seed(42)
+    random.seed(42)
+
+    engine = get_db_engine()
+
+    print("=== 행동 기반 (calculate_activity_scores) 랭킹 평가 ===")
+    beh = evaluate_behavior_model(engine, k=10, negative_pool=100, seed=42)
+    print(beh)
+
+    print("\n=== 협업 필터링 (RMSE/MAE) ===")
+    ratings = load_ratings(engine)
+    cf_err = eval_surprise_rmse_mae(ratings)
+    print(cf_err)
+
+    print("\n=== 협업 필터링 (랭킹: leave-last-out) ===")
+    cf_rank = eval_surprise_ranking(ratings, k=10, negative_pool=100)
+    print(cf_rank)


### PR DESCRIPTION
## 📌 개요
2. 행동 기반 콘텐츠 필터링, 3. 협업 필터링 함수
위 두 알고리즘에 대한 정확도 검증

## ✅ 작업 내용
evaluation_wish.py
- 행동 기반 평가
  - cutoff_ts + exclude_event_ids로 테스트 아이템 누수 방지
  - 유저별 최신 1개 홀드아웃 & 나머지로 스코어링
  - 네거티브 샘플링(negative_pool) 도입, k@10 지표(Precision/Recall/MAP/nDCG) 계산
  - 평가 대상 유저 수/파라미터 로그 출력([Behavior Eval] …)

- 협업 필터링 평가
  - load_ratings: created_at 파싱 + (user,item) 최신 기록만 유지하도록 dedup
  - RMSE/MAE: KFold로 KNNBaseline, SVD 모두 비교
  - 랭킹(leave-last-out):
    - 글로벌 빈도 고려 + train에 아이템이 남도록 테스트 인덱스 선택
    - 후보군 구성 옵션화(use_all_candidates, negative_pool, skip_cold)
    - 평가 유저 수/콜드 스킵 수/평균 후보 수 로그 출력([CF Rank:…])

algo.py
- 콘텐츠 기반
  - 제목 전처리 title_clean 적용(불용기호/특수문자 제거 + 품사 필터), 메타에 반영
  - TF-IDF 벡터화기 캐싱(_ensure_vectorizer) 및 재사용으로 일관성/성능 개선
  - DB 엔진 커넥션 캐싱(pool_pre_ping)로 안정성 향상

- 행동 기반 조정
  - 사용자별 행동 점수 Min–Max 정규화 후 (1 + adj) * similarity로 반영(스케일 안정화)

- 협업 필터링
  - 예측 모델을 SVD(n_factors=10, n_epochs=30, reg_all=0.05)로 전환
  - 학습에 등장한 아이템 중 미시청 후보만 스코어링, 원 순서 보존하여 결과 머지

## 📸 화면 캡처 (선택)
<img width="814" height="496" alt="image" src="https://github.com/user-attachments/assets/548fba41-328e-4287-a34b-6abbc45cd87a" />

## 🔍 중점 리뷰 요청 부분
- 평가 프로토콜/데이터 분할 로직 타당성
- 누수 방지(cutoff_ts, exclude_event_ids) 구현
- 후보군 구성(use_all_candidates / negative_pool / skip_cold) 파라미터
- SVD/KNNBaseline 하이퍼파라미터

## 🔗 관련 이슈
#60 
