### PR TITLE
[fix] 챗봇 시나리오 수정

### DIFF
--- a/boogi-bot/data/rules.yml
+++ b/boogi-bot/data/rules.yml
@@ -31,17 +31,32 @@ rules:
     - intent: show_more
     - action: action_show_more
 
-# 새로 추가: 페이지네이션 중 affirm이면 곧장 더보기
-- rule: User affirms while paginating -> show more
+# 새로 추가: 다른 분류의 행사 추천 동의시 -> action_determine_next_step
+- rule: User affirms while paginating -> action_determine_next_step
   condition:
     - slot_was_set:
         - page: true
+        - area: true
+        - category: true
   steps:
     - intent: affirm
-    - action: action_show_more
+    - action: action_determine_next_step
 
-- rule: User denies
+- rule: Say thanks and close on deny
   steps:
     - intent: deny
+    - action: utter_thanks_bye
     - action: action_listen
+
+# 중복 질문 방지
+- rule: Listen after asking area
+  steps:
+    - action: utter_ask_area
+    - action: action_listen
+
+- rule: Listen after asking category
+  steps:
+    - action: utter_ask_category
+    - action: action_listen
+
 

--- a/boogi-bot/data/stories.yml
+++ b/boogi-bot/data/stories.yml
@@ -25,8 +25,8 @@ stories:
     - action: action_show_more
 
 #affirm으로 더보기
-- story: show more via affirm
-  steps:
-    - intent: affirm
-    - action: action_show_more
+# - story: show more via affirm
+#   steps:
+#     - intent: affirm
+#     - action: action_show_more
 

--- a/boogi-bot/domain.yml
+++ b/boogi-bot/domain.yml
@@ -92,6 +92,9 @@ responses:
   utter_default:
     - text: "제가 잘 이해하지 못했어요. 지역/종류를 알려주시면 바로 추천해드려요!"
 
+  utter_thanks_bye:
+    - text: "이용해주셔서 감사합니다. 언제든지 다시 불러주세요:)"
+
 
 actions:
   - action_determine_next_step


### PR DESCRIPTION
## 📌 개요
챗봇 시나리오 수정

## ✅ 작업 내용
- “더 보기” 페이징 로직 개선, 모든 페이지에서 재요청 힌트 노출
- 중복 질문(지역/분류) 2회 출력 문제 해결
- 거절(deny) 시 감사 멘트로 종료
- 토큰/엔드포인트/네트워크 처리 강화 및 로깅 정비
- NLU 학습 문장 확장

## 📸 화면 캡처 (선택)

## 🔍 중점 리뷰 요청 부분
**<actions.py>**

- ActionDetermineNextStep, ActionRecommendEvent에서 질문 템플릿 직접 출력 → **FollowupAction("utter_ask_*")**로 변경 (중복 질문 해결)

- ActionShowMore:
has_more/next/next_page 기반 페이지네이션
아이템 출력 후 “더 볼까요? '더 보기'라고 말해보세요!” 안내를 모든 중간 페이지에 노출
마지막 페이지면 슬롯 리셋 + 플로우 재시작(_reset_and_restart)

- ActionRecommendEvent:
결과 없을 때 “조건에 맞는 행사가 지금은 없네요…” + 리셋/재시작
마지막 페이지면 “여기까지가 끝! …” + 리셋/재시작


**<rules.yml>**

- Decide next step for recommendation/Show more results 등 기본 흐름 규칙 
- 중복 질문 방지 규칙
    utter_ask_area → action_listen
    utter_ask_category → action_listen
- deny 시 utter_thanks_bye 실행 후 action_listen
- 페이징 중 affirm 대응(선택 규칙)

## 🔗 관련 이슈
#55
